### PR TITLE
Mark endpoint as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+**This endpoint is deprecated.**
+
+Original README contents follows:
+
 # Abandoned Carts Endpoint
 
 For a detailted explanation check out the [Spree Guides - Abandoned Carts Endpoint](http://guides.spreecommerce.com/integration/abandoned_carts_integration.html).


### PR DESCRIPTION
As a follow-up to #1, here is a change to make it clear that this endpoint is deprecated.